### PR TITLE
bugfix not supported between instances

### DIFF
--- a/IntuneUploader/IntuneAppCleaner.py
+++ b/IntuneUploader/IntuneAppCleaner.py
@@ -63,7 +63,7 @@ class IntuneAppCleaner(IntuneUploaderBase):
         )
 
         # When running from the command line, keep_versions is a string, convert to int
-        if isinstance(keep_versions, int):
+        if isinstance(keep_versions, str):
             keep_versions = int(keep_versions)
 
         # Get macthing apps


### PR DESCRIPTION
Running IntuneAppCleaner failed with `'>' not supported between instances of 'int' and 'str'` as it was not converting the str to an int.