### PR TITLE
Update Claude Unarchiver Actions

### DIFF
--- a/Anthropic/Claude.download.recipe
+++ b/Anthropic/Claude.download.recipe
@@ -47,7 +47,9 @@
 				<key>archive_path</key>
 				<string>%pathname%</string>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%</string>
+				<string>%RECIPE_CACHE_DIR%/unpacked</string>
+				<key>purge_destination</key>
+				<true/>
 			</dict>
 			<key>Processor</key>
 			<string>Unarchiver</string>
@@ -56,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/Claude.app</string>
+				<string>%RECIPE_CACHE_DIR%/unpacked/Claude.app</string>
 				<key>requirement</key>
 				<string>identifier "com.anthropic.claudefordesktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Q6L2SF6YDW</string>
 			</dict>
@@ -69,7 +71,7 @@
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/Claude.app</string>
+				<string>%RECIPE_CACHE_DIR%/unpacked/Claude.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>DmgCreator</string>


### PR DESCRIPTION
Fixes code signature verification failures when attempting to import using a munki recipe due to a new version being copied atop the previous version and cruft files remaining.