### PR TITLE
Adjust Fantastical intune recipe parent

### DIFF
--- a/Fantastical/Fantastical.intune.recipe
+++ b/Fantastical/Fantastical.intune.recipe
@@ -24,7 +24,7 @@
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.jaharmi.download.Fantastical</string>
+	<string>com.github.macprince.download.Fantastical</string>
 	<key>Process</key>
 	<array>
         <dict>


### PR DESCRIPTION
The Fantastical download recipe in jaharmi-recipes is under consideration for deprecation (https://github.com/autopkg/jaharmi-recipes/pull/119). This PR updates the intune recipe in this repo to use macprince-recipes' download as a parent.

The download format is compatible — verified by running the recipe after the change.

Thank you for considering!