### PR TITLE
Fix adobe package name

### DIFF
--- a/Adobe/AdobeReader.intune.recipe
+++ b/Adobe/AdobeReader.intune.recipe
@@ -31,7 +31,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/*/application.pkg</string>
+				<string>%RECIPE_CACHE_DIR%/*/application_mini_7z.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileFinder</string>


### PR DESCRIPTION
As per the discussion thread in the Mac Admins autopkg channel dated 2026-04-03, adobe seem to have changed some internal things in the package. The upstream recipes were updated to reflect these changes in https://github.com/autopkg/recipes/pull/543, however the Intune recipe is still referencing the old file name causing failures. This PR resolves that problem. I've tested it locally and its built a deployed successfully to my Intune environment.

This is the build failure that I was seeing before this change:
```
speeddaemon@L0000405 mac-autopkg-apps % rm -Rf .autopkg-cache
speeddaemon@L0000405 mac-autopkg-apps % autopkg run -v \
  --post com.github.almenscorner.intune-upload.processors/IntuneAppCleaner \
  -k display_name="Adobe Reader" \
  -k keep_version_count=1 \
  AdobeReader.intune.recipe
Processing AdobeReader.intune.recipe...
AdobeReaderURLProvider
AdobeReaderURLProvider: [displayName] : Reader 2026.001.21529 for Mac
AdobeReaderURLProvider: [version]     : 26.001.21529
AdobeReaderURLProvider: [download_url]: https://ardownload3.adobe.com/pub/adobe/acrobat/mac/AcrobatDC/2600121529/AcroRdrSCADC2600121529_MUI.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 30 Apr 2026 10:32:42 GMT
URLDownloader: Storing new ETag header: "30188865-650aafbfa8fa3"
URLDownloader: Downloaded /Users/speeddaemon/workspace/IntuneApps/mac-autopkg-apps/.autopkg-cache/local.intune.AdobeReader/downloads/Adobe Reader.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/speeddaemon/workspace/IntuneApps/mac-autopkg-apps/.autopkg-cache/local.intune.AdobeReader/downloads/Adobe Reader.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.qxXeXZ/AcroRdrSCADC2600121529_MUI.pkg' matched from globbed '/private/tmp/dmg.qxXeXZ/*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "AcroRdrSCADC2600121529_MUI.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2026-04-29 21:43:55 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Adobe Inc. (JQ525L2MZD)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            97 9A 81 BE 07 15 BA 87 99 0E AD DC AE 97 A7 98 08 19 8A 1E DE 0F
CodeSignatureVerifier:            4A 42 0D CE 38 96 80 A1 CE BF
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
AdobeReaderRepackager
AdobeReaderRepackager: Mounted disk image /Users/speeddaemon/workspace/IntuneApps/mac-autopkg-apps/.autopkg-cache/local.intune.AdobeReader/downloads/Adobe Reader.dmg
AdobeReaderRepackager: Replaced pkg preinstall script with our custom script at /Users/speeddaemon/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/AdobeReader/package_resources/scripts/reader_preinstall
FileFinder
FileFinder: Found file match: '/Users/speeddaemon/workspace/IntuneApps/mac-autopkg-apps/.autopkg-cache/local.intune.AdobeReader/AcroRdrSCADC2600121529_MUI/application_mini_7z.pkg' from globbed '/Users/speeddaemon/workspace/IntuneApps/mac-autopkg-apps/.autopkg-cache/local.intune.AdobeReader/*/application_mini_7z.pkg'
FileFinder: Basename match: 'application_mini_7z.pkg'
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/speeddaemon/workspace/IntuneApps/mac-autopkg-apps/.autopkg-cache/local.intune.AdobeReader/AcroRdrSCADC2600121529_MUI/application_mini_7z.pkg/Payload to /Users/speeddaemon/workspace/IntuneApps/mac-autopkg-apps/.autopkg-cache/local.intune.AdobeReader
FileFinder
FileFinder: Found file match: '/Users/speeddaemon/workspace/IntuneApps/mac-autopkg-apps/.autopkg-cache/local.intune.AdobeReader/Adobe Acrobat.app' from globbed '/Users/speeddaemon/workspace/IntuneApps/mac-autopkg-apps/.autopkg-cache/local.intune.AdobeReader/*.app'
FileFinder: Basename match: 'Adobe Acrobat.app'
Versioner
Versioner: Found version 26.001.21529 in file /Users/speeddaemon/workspace/IntuneApps/mac-autopkg-apps/.autopkg-cache/local.intune.AdobeReader/Adobe Acrobat.app/Contents/Info.plist
PathDeleter
PathDeleter: Deleted /Users/speeddaemon/workspace/IntuneApps/mac-autopkg-apps/.autopkg-cache/local.intune.AdobeReader/Adobe Acrobat.app
PkgCopier
PkgCopier: Copied /Users/speeddaemon/workspace/IntuneApps/mac-autopkg-apps/.autopkg-cache/local.intune.AdobeReader/AcroRdrSCADC2600121529_MUI.pkg to /Users/speeddaemon/workspace/IntuneApps/mac-autopkg-apps/.autopkg-cache/local.intune.AdobeReader/Adobe Reader-26.001.21529.pkg
FileFinder
No matching filename found
Failed.
Receipt written to /Users/speeddaemon/workspace/IntuneApps/mac-autopkg-apps/.autopkg-cache/local.intune.AdobeReader/receipts/AdobeReader.intune-receipt-20260513-094913.plist

The following recipes failed:
    AdobeReader.intune.recipe
        Error in local.intune.AdobeReader: Processor: FileFinder: Error: No matching filename found

The following new items were downloaded:
    Download Path
    -------------
    /Users/speeddaemon/workspace/IntuneApps/mac-autopkg-apps/.autopkg-cache/local.intune.AdobeReader/downloads/Adobe Reader.dmg

The following packages were copied:
    Pkg Path
    --------
    /Users/speeddaemon/workspace/IntuneApps/mac-autopkg-apps/.autopkg-cache/local.intune.AdobeReader/Adobe Reader-26.001.21529.pkg
```