### PR TITLE
Claude: avoid hdiutil volname collision with installed Claude.app

### DIFF
--- a/Anthropic/Claude.download.recipe
+++ b/Anthropic/Claude.download.recipe
@@ -71,7 +71,7 @@
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/unpacked/Claude.app</string>
+				<string>%RECIPE_CACHE_DIR%/unpacked</string>
 			</dict>
 			<key>Processor</key>
 			<string>DmgCreator</string>


### PR DESCRIPTION
With Claude.app installed, `DmgCreator` fails because `-srcfolder .../unpacked/Claude.app` makes `hdiutil` derive volname `Claude`, and macOS blocks creating `/Volumes/Claude` on a machine where that name is claimed. Pointing `dmg_root` at the `unpacked` parent directory instead makes the volname `unpacked`; `hdiutil create -srcfolder <dir>` still places `Claude.app` at the root of the resulting DMG.

### Before (current `main`)

```
DmgCreator
{'Input': {'dmg_path': '<RECIPE_CACHE_DIR>/Claude.dmg',
           'dmg_root': '<RECIPE_CACHE_DIR>/unpacked/Claude.app'}}
DmgCreator: No value supplied for dmg_format, setting default value of: UDZO
DmgCreator: No value supplied for dmg_filesystem, setting default value of: HFS+
DmgCreator: No value supplied for dmg_zlib_level, setting default value of: 5
Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/__init__.py", line 898, in process
    self.env = processor.process()
  File "/Library/AutoPkg/autopkglib/__init__.py", line 643, in process
    self.main()
  File "/Library/AutoPkg/autopkglib/DmgCreator.py", line 159, in main
    raise ProcessorError(f"creation of {self.env['dmg_path']} failed: {stderr}")
autopkglib.ProcessorError: creation of <RECIPE_CACHE_DIR>/Claude.dmg failed: hdiutil: create failed - Operation not permitted
```

### After

```
DmgCreator
{'Input': {'dmg_path': '<RECIPE_CACHE_DIR>/Claude.dmg',
           'dmg_root': '<RECIPE_CACHE_DIR>/unpacked'}}
DmgCreator: No value supplied for dmg_format, setting default value of: UDZO
DmgCreator: No value supplied for dmg_filesystem, setting default value of: HFS+
DmgCreator: No value supplied for dmg_zlib_level, setting default value of: 5
DmgCreator: Created dmg from <RECIPE_CACHE_DIR>/unpacked at <RECIPE_CACHE_DIR>/Claude.dmg
AppDmgVersioner
AppDmgVersioner: Mounted disk image <RECIPE_CACHE_DIR>/Claude.dmg
AppDmgVersioner: BundleID: com.anthropic.claudefordesktop
AppDmgVersioner: Version: 1.8555.1
```
